### PR TITLE
Replace `String.fromEnvironment` since it doesn't work

### DIFF
--- a/test/api/test_config.dart
+++ b/test/api/test_config.dart
@@ -12,15 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-class TestConfig {
-  const TestConfig._();
+import 'package:universal_io/io.dart';
 
-  static const cosmosDBUrl = String.fromEnvironment('COSMOS_DB_URL',
-      defaultValue: 'https://localhost:8081/');
-  static const cosmosDBMasterKey = String.fromEnvironment(
-      'COSMOS_DB_MASTER_KEY',
-      defaultValue:
-          'C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==');
-  static const ignoreSelfSignedCertificates =
-      bool.fromEnvironment('COSMOS_DB_IGNORE_SSL', defaultValue: true);
+class TestConfig {
+  late final String cosmosDBUrl;
+  late final String cosmosDBMasterKey;
+  late final bool ignoreSelfSignedCertificates;
+
+  TestConfig() {
+    cosmosDBUrl =
+        Platform.environment['COSMOS_DB_URL'] ?? 'https://localhost:8081/';
+    cosmosDBMasterKey = Platform.environment['COSMOS_DB_MASTER_KEY'] ??
+        'C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==';
+    ignoreSelfSignedCertificates =
+        Platform.environment['COSMOS_DB_IGNORE_SSL'] != null;
+  }
 }

--- a/test/api/utils.dart
+++ b/test/api/utils.dart
@@ -29,12 +29,21 @@ String generateId() {
 
 CosmosDB buildClient() {
   final client = HttpClient();
-  if (TestConfig.ignoreSelfSignedCertificates) {
+  final config = TestConfig();
+  if (config.ignoreSelfSignedCertificates) {
     client.badCertificateCallback = (_, __, ___) => true;
   }
+  print('CosmosDB buildClient()');
+  print(Platform.environment['COSMOS_DB_URL']);
+  print(Platform.environment['COSMOS_DB_MASTER_KEY']);
+  const urlIsDeclared = bool.hasEnvironment('COSMOS_DB_URL');
+  const url = String.fromEnvironment('COSMOS_DB_URL');
+  print('urlIsDeclared=$urlIsDeclared; url=$url');
+  print(config.cosmosDBUrl);
+  print(config.cosmosDBMasterKey);
   return CosmosDB(
-    masterKey: TestConfig.cosmosDBMasterKey,
-    baseUrl: TestConfig.cosmosDBUrl,
+    masterKey: config.cosmosDBMasterKey,
+    baseUrl: config.cosmosDBUrl,
     httpClient: IOClient(client),
   );
 }

--- a/test/api/utils.dart
+++ b/test/api/utils.dart
@@ -33,14 +33,6 @@ CosmosDB buildClient() {
   if (config.ignoreSelfSignedCertificates) {
     client.badCertificateCallback = (_, __, ___) => true;
   }
-  print('CosmosDB buildClient()');
-  print(Platform.environment['COSMOS_DB_URL']);
-  print(Platform.environment['COSMOS_DB_MASTER_KEY']);
-  const urlIsDeclared = bool.hasEnvironment('COSMOS_DB_URL');
-  const url = String.fromEnvironment('COSMOS_DB_URL');
-  print('urlIsDeclared=$urlIsDeclared; url=$url');
-  print(config.cosmosDBUrl);
-  print(config.cosmosDBMasterKey);
   return CosmosDB(
     masterKey: config.cosmosDBMasterKey,
     baseUrl: config.cosmosDBUrl,


### PR DESCRIPTION
The prior code didn't pull the environment variables and this does!