### PR TITLE
Add partitionKeys to collection creation and document operations

### DIFF
--- a/lib/src/api/collection_api.dart
+++ b/lib/src/api/collection_api.dart
@@ -50,9 +50,16 @@ class CollectionApi {
   /// Creates a new collection in the given database
   Future<void> create(String databaseId, String collectionId,
       {CosmosRequestOptions? options}) {
+    var partitionKeys = options?.partitionKeys ?? ['/id'];
     return _client.post(
       'dbs/$databaseId/colls',
-      {'id': collectionId},
+      {
+        'id': collectionId,
+        'partitionKey': {
+          'paths': partitionKeys,
+          'kind': 'Hash',
+        }
+      },
       resourceType: ResourceType.container,
       removeLastPart: true,
       headers: options?.toHeaders() ?? const {},

--- a/lib/src/api/document_api.dart
+++ b/lib/src/api/document_api.dart
@@ -56,23 +56,25 @@ class DocumentApi {
   Future<Map<String, dynamic>> replace(Map<String, dynamic> newDocument,
       String databaseId, String collectionId, String documentId,
       {CosmosRequestOptions? options}) {
+    options ??= CosmosRequestOptions(partitionKeys: [documentId]);
     return _client.put(
       'dbs/$databaseId/colls/$collectionId/docs/$documentId',
       newDocument,
       resourceType: ResourceType.item,
       removeLastPart: false,
-      headers: options?.toHeaders() ?? const {},
+      headers: options.toHeaders(),
     );
   }
 
   /// Deletes the document with the given id in the collection
   Future<void> delete(String databaseId, String collectionId, String documentId,
       {CosmosRequestOptions? options}) async {
+    options ??= CosmosRequestOptions(partitionKeys: [documentId]);
     await _client.delete(
       'dbs/$databaseId/colls/$collectionId/docs/$documentId',
       resourceType: ResourceType.item,
       removeLastPart: false,
-      headers: options?.toHeaders() ?? const {},
+      headers: options.toHeaders(),
     );
   }
 
@@ -80,11 +82,12 @@ class DocumentApi {
   Future<Map<String, dynamic>> findById(
       String databaseId, String collectionId, String documentId,
       {CosmosRequestOptions? options}) async {
+    options ??= CosmosRequestOptions(partitionKeys: [documentId]);
     return await _client.get(
       'dbs/$databaseId/colls/$collectionId/docs/$documentId',
       resourceType: ResourceType.item,
       removeLastPart: false,
-      headers: options?.toHeaders() ?? const {},
+      headers: options.toHeaders(),
     );
   }
 
@@ -99,12 +102,13 @@ class DocumentApi {
     if (!document.containsKey('id')) {
       throw ArgumentError('id in document is required');
     }
+    options ??= CosmosRequestOptions(partitionKeys: [document['id']]);
     return await _client.post(
       'dbs/$databaseId/colls/$collectionId/docs',
       document,
       removeLastPart: true,
       resourceType: ResourceType.item,
-      headers: options?.toHeaders() ?? {},
+      headers: options.toHeaders(),
     );
   }
 }


### PR DESCRIPTION
A partitionKey is required for collections created through the portal. "If the REST API version is 2018-12-31 or higher, the collection must include a partitionKey definition." [cite](https://docs.microsoft.com/en-us/rest/api/cosmos-db/create-a-collection). Using `id` as the partitionKey is [recommended](https://docs.microsoft.com/en-us/azure/cosmos-db/partitioning-overview#using-item-id-as-the-partition-key). This change simplifies the client's code.